### PR TITLE
Add initWebGPU calls

### DIFF
--- a/webgpu-events-smoke-test.v8e
+++ b/webgpu-events-smoke-test.v8e
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/test.js
+#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/test.js -f lib/timers.js
 /**
  * @file      webgpu-events-smoke-test.v8e - tries to add an event listener on device. Known to fail /wg aug 2024
  * @author    Wes Garland
@@ -25,6 +25,10 @@ if (!globalThis.EventTarget)
 
 globalThis.main = async function main()
 {
+  // dcp-native > 7.2.0 lazy loads webgpu
+  if (typeof initWebGPU === 'function')
+    await initWebGPU();
+
   console.log('\nusing userland EventTarget:', userlandEventTarget);
   console.log('GPUDevice is', GPUDevice);
   console.log('GPUDevice prototype is', GPUDevice.prototype);

--- a/webgpu-matmul.v8e
+++ b/webgpu-matmul.v8e
@@ -11,6 +11,10 @@
 
 globalThis.main = async function main()
 {
+  // dcp-native > 7.2.0 lazy loads webgpu
+  if (typeof initWebGPU === 'function')
+    await initWebGPU();  
+
   const BLOCK_SIZE_X = 16;
   const BLOCK_SIZE_Y = 16;
 

--- a/webgpu-request-adapters.v8e
+++ b/webgpu-request-adapters.v8e
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js
+#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/timers.js
 /**
  * @file      webgpu-test.v8e - Basic webgpu functionality tests. Runs on the bare-metal dcp-evaluator
  *                              for v8 + webgpu
@@ -45,6 +45,10 @@ async function summarizeAdapter(powerPreference, adapter)
 
 globalThis.main = async function main()
 {
+  // dcp-native > 7.2.0 lazy loads webgpu
+  if (typeof initWebGPU === 'function')
+    await initWebGPU();
+
   const hpAdapter = await getAdapter('high-performance');
   summarizeAdapter('high-power', hpAdapter);
   const lpAdapter = await getAdapter('low-power');

--- a/webgpu-smoke-test.v8e
+++ b/webgpu-smoke-test.v8e
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js
+#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/timers.js
 /**
  * @file      webgpu-test.v8e - Basic webgpu functionality tests. Runs on the bare-metal dcp-evaluator
  *                              for v8 + webgpu
@@ -9,6 +9,10 @@
 
 globalThis.main = async function main()
 {
+  // dcp-native > 7.2.0 lazy loads webgpu
+  if (typeof initWebGPU === 'function')
+    await initWebGPU();
+
   if (globalThis.navigator && globalThis.navigator?.gpu)
     console.log("Your evaluator has WebGPU support");
   else

--- a/webgpu-test-enumeration.v8e
+++ b/webgpu-test-enumeration.v8e
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/test.js
+#! /usr/bin/env -S /opt/dcp/bin/dcp-evaluator --webgpu -f lib/console.js -f lib/rt.js -f lib/test.js -f lib/timers.js
 /**
  * @file      webgpu-events-smoke-test.v8e - tries to add an event listener on device. Known to fail /wg aug 2024
  * @author    Wes Garland
@@ -8,6 +8,10 @@
 
 globalThis.main = async function main()
 {
+  // dcp-native > 7.2.0 lazy loads webgpu
+  if (typeof initWebGPU === 'function')
+    await initWebGPU();
+
   const gprops = [];
   const nprops = [];
 


### PR DESCRIPTION
In pre-release versions of dcp-native, we have `initWebGPU` to lazy load webgpu (for a variety of current & future reasons). But, that means any of these scripts that want to use webgpu will need to call that function, so do so.